### PR TITLE
If a trie is empty, find_all should return []

### DIFF
--- a/cidr_trie/__init__.py
+++ b/cidr_trie/__init__.py
@@ -324,6 +324,8 @@ class PatriciaTrie:
         Raises:
             ValueError: When trying to find an IPv4 address in a v6 trie and vice-versa.
         """
+        if self.size == 0:
+            return []
         self.validate_ip_type_for_trie(prefix)
         result = []
         ip, mask = cidr_atoi(prefix)


### PR DESCRIPTION
If a trie is empty, there is no point in validating its IP type or running any of the rest of the logic. Indeed, if you validate an IP v6 against an empty trie, you will get an error (because self.v6 always defaults to false, and will not be changed until at least one IP v6 item is added to the trie).